### PR TITLE
add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This app is designed to work with Kodi/XBMC to make it easy to navigate your
 library and control the media center directly from your Firefox OS device.
 This uses a websocket to connect to your media server and communicate via the
-JSON-RPC API.
+[JSON-RPC API](<http://kodi.wiki/view/JSON_RPC>).
 
 Desgined and tested with Kodi 14.0 "Helix" (http://kodi.tv/). This should be
 compatible with XBMC 12.x and 13.x as well, and is untested on earlier versions.
@@ -18,7 +18,7 @@ compatible with XBMC 12.x and 13.x as well, and is untested on earlier versions.
 * Generated thumbnails for all media
 * Basic remote interface for navigational controls
 
-### Planned
+#### Planned
 * Support for music controls
 * Support for creating a playlist
 * ???
@@ -31,7 +31,14 @@ image is retrieved once, it is cached on the device to reduce bandwidth and
 increase performance. This requires the "storage" permission for storing image
 thumbnails in IndexedDB.
 
-### Chanelog
+### Setup instructions
+1. To enable remote control via TCP/WebSocket you need to check that "Allow programs on other systems to control Kodi/XBMC" in System/Settings/Network/Services is enabled.
+
+2. When launching Foxi you will be asked to enter the host address and TCP port used by the JSON-RPC.
+You can find your host's IP address in Kodi/XBMC under the System info tab.
+The default port used by the JSON-RPC is 9090.
+
+### Changelog
 
 * *v0.1.0*: Initial Release; supports Movies and TV Shows
 


### PR DESCRIPTION
- add link to the API documentation
- add setup instructions
- cleanup: make planned features a subcategory of features, fix typo
